### PR TITLE
switch submodule URL to use HTTPS rather than SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "uuid-random"]
 	path = uuid-random
-	url = git@github.com:jchook/uuid-random.git
+	url = https://github.com/jchook/uuid-random.git


### PR DESCRIPTION
Trying to deploy a github.io site with this repo results in a build error:

> The submodule registered for `./uuid-random` could not be cloned. Make sure it's using https:// and that it's a public repo. For more information, see https://docs.github.com/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites#invalid-submodule.

This PR switches the submodule URL from SSH to HTTPS.